### PR TITLE
Pull account details and use official account names

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,15 @@ const { getTransactions } = require('./providers/plaid');
 const { parseEnvOrDefault } = require('./lib/common');
 
 (async () => {
-  const defaultTransactionColumns = ['date', 'amount', 'name', 'account', 'category.0', 'category.1', 'pending'];
+  const defaultTransactionColumns = [
+    'date',
+    'amount',
+    'name',
+    'account_details.official_name',
+    'category.0',
+    'category.1',
+    'pending'
+  ];
   const defaultReferenceColumns = ['notes', 'work', 'joint'];
   const defaultSpreadsheetProvider = 'sheets';
   const defaultTransactionProvider = 'plaid';
@@ -38,7 +46,7 @@ const { parseEnvOrDefault } = require('./lib/common');
       ({ currentMonthTransactions, lastMonthTransactions } = await getTransactions(
         transactionColumns,
         categoryOverrides,
-        currentMonthSheetTitle,
+        currentMonthSheetTitle
       ));
       break;
 
@@ -59,7 +67,7 @@ const { parseEnvOrDefault } = require('./lib/common');
         lastTransactionColumn,
         firstReferenceColumn,
         lastReferenceColumn,
-        numAutomatedColumns,
+        numAutomatedColumns
       );
       break;
 

--- a/lib/plaid.js
+++ b/lib/plaid.js
@@ -61,18 +61,10 @@ exports.fetchTransactions = async function() {
 };
 
 exports.fetchBalances = async function() {
-  const rawBalances = await Promise.all(
+  console.log('Fetching Account Balances...');
+  return await Promise.all(
     plaidAccountTokens.map(({ account, token }) => {
       return client.getBalance(token);
     })
   );
-
-  return rawBalances.reduce((all, { accounts }) => {
-    return all.concat(
-      accounts.map(({ name, balances }) => ({
-        name,
-        balance: balances.current
-      }))
-    );
-  }, []);
 };

--- a/lib/sheets.js
+++ b/lib/sheets.js
@@ -18,21 +18,18 @@ const sheets = google.sheets({
 
 exports.getSheets = async function(spreadsheetId) {
   return new Promise((resolve, reject) =>
-    sheets.spreadsheets.get(
-      { spreadsheetId },
-      (err, res) => {
-        if (err) {
-          console.log('Fetch failed:', err);
-          reject(err);
-        }
-        console.log(`Success! Fetched current sheets.`);
-        resolve(res.data.sheets);
+    sheets.spreadsheets.get({ spreadsheetId }, (err, res) => {
+      if (err) {
+        console.log('Fetch failed:', err);
+        reject(err);
       }
-    )
+      console.log(`Success! Fetched current sheets.`);
+      resolve(res.data.sheets);
+    })
   );
 };
 
-exports.duplicateSheet = async function (sourceSpreadsheetId, sourceSheetId) {
+exports.duplicateSheet = async function(sourceSpreadsheetId, sourceSheetId) {
   return new Promise((resolve, reject) =>
     sheets.spreadsheets.sheets.copyTo(
       {

--- a/providers/plaid.js
+++ b/providers/plaid.js
@@ -1,10 +1,12 @@
 const moment = require('moment');
 const _ = require('lodash');
-const { fetchTransactions } = require('../lib/plaid');
+const { fetchTransactions, fetchBalances } = require('../lib/plaid');
 
 exports.getTransactions = async (transactionColumns, categoryOverrides, currentMonthSheetTitle) => {
-  const sanitizeTransaction = (transaction) => {
+  const sanitizeTransaction = (transaction, accounts) => {
     let sanitized = transaction;
+
+    sanitized['account_details'] = _.get(accounts, transaction.account_id, {});
 
     /*
      * Explode out Plaid's object hierarchy.
@@ -20,19 +22,19 @@ exports.getTransactions = async (transactionColumns, categoryOverrides, currentM
      *
      *    { "category.0": "Food and Drink", "category.1": "Restaurants" }
      */
-    _.forEach(transactionColumns, (column) => {
+    _.forEach(transactionColumns, column => {
       sanitized[column] = _.get(sanitized, column);
     });
 
     // Map TRUE to 'y' and FALSE to nothing (used for Pending column)
-    sanitized = _.mapValues(sanitized, (p) => {
+    sanitized = _.mapValues(sanitized, p => {
       let prop = p === true ? 'y' : p;
       prop = p === false ? '' : p;
       return prop;
     });
 
     // Handle category overrides defined in .env
-    _.forEach(categoryOverrides, (override) => {
+    _.forEach(categoryOverrides, override => {
       if (new RegExp(override.pattern, _.get(override, 'flags', '')).test(sanitized.name)) {
         sanitized['category.0'] = _.get(override, 'category.0', '');
         sanitized['category.1'] = _.get(override, 'category.1', '');
@@ -42,18 +44,23 @@ exports.getTransactions = async (transactionColumns, categoryOverrides, currentM
     return sanitized;
   };
 
+  const accounts = await fetchBalances();
+  const clean_accounts = _.keyBy(_.flatten(_.map(accounts, item => item.accounts)), 'account_id');
+
   const transactions = await fetchTransactions();
   const sorted = _.sortBy(transactions, 'date');
-  const sanitized = _.map(sorted, sanitizeTransaction);
+  const sanitized = _.map(sorted, transaction => sanitizeTransaction(transaction, clean_accounts));
+
   const partitioned = _.partition(
     sanitized,
-    transaction => moment(transaction.date)
-      .startOf('month')
-      .format('YYYY.MM') === currentMonthSheetTitle,
+    transaction =>
+      moment(transaction.date)
+        .startOf('month')
+        .format('YYYY.MM') === currentMonthSheetTitle
   );
 
   return {
     currentMonthTransactions: _.map(partitioned[0], transaction => _.at(transaction, transactionColumns)),
     lastMonthTransactions: _.map(partitioned[1], transaction => _.at(transaction, transactionColumns))
-  }
+  };
 };

--- a/providers/sheets.js
+++ b/providers/sheets.js
@@ -6,7 +6,7 @@ const {
   formatHeaderRow,
   resizeColumns,
   duplicateSheet,
-  renameSheet,
+  renameSheet
 } = require('../lib/sheets');
 
 exports.updateSheets = async (
@@ -20,7 +20,7 @@ exports.updateSheets = async (
   lastTransactionColumn,
   firstReferenceColumn,
   lastReferenceColumn,
-  numAutomatedColumns,
+  numAutomatedColumns
 ) => {
   const publicTemplateSheetId = '10fYhPJzABd8KlgAzxtiyFN-L_SebTvM8SaAK_wHk-Fw';
 
@@ -55,13 +55,13 @@ exports.updateSheets = async (
     // Column headers for transaction data
     updates.push({
       range: `${sheetTitle}!${firstTransactionColumn}1:${lastTransactionColumn}1`,
-      values: [transactionColumns],
+      values: [transactionColumns]
     });
 
     // Additional user-defined reference column headers (specify in .env)
     updates.push({
       range: `${sheetTitle}!${firstReferenceColumn}1:${lastReferenceColumn}1`,
-      values: [referenceColumns],
+      values: [referenceColumns]
     });
 
     return updates;


### PR DESCRIPTION
Fixes #13 – now we pull real account names (like `Chase Sapphire Reserve` instead of `CHASE`).