### PR TITLE
Fix red herring errors in CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "mintable.js",
   "author": "Kevin Schaich",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "circleci:dry-run": "circleci local execute -e MINTABLE_CONFIG=$MINTABLE_CONFIG",
     "export": "node ./src/scripts/export.js",

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -37,14 +37,14 @@ const getConfigEnv = () => {
         ...envConfig
       }
       return envConfig
+    } else {
+      const config = fs.readFileSync(CONFIG_FILE)
+      process.env = {
+        ...process.env,
+        ...JSON.parse(config)
+      }
+      return JSON.parse(config)
     }
-
-    const config = fs.readFileSync(CONFIG_FILE)
-    process.env = {
-      ...process.env,
-      ...JSON.parse(config)
-    }
-    return JSON.parse(config)
   } catch (e) {
     console.log('Error: Could not read config file. ' + e.message)
     return false

--- a/src/lib/google/googleClient.js
+++ b/src/lib/google/googleClient.js
@@ -1,7 +1,4 @@
 const { google } = require("googleapis");
-const { getConfigEnv } = require("../common");
-
-getConfigEnv();
 
 module.exports = new google.auth.OAuth2(
   process.env.SHEETS_CLIENT_ID,

--- a/src/lib/google/sheets.js
+++ b/src/lib/google/sheets.js
@@ -1,9 +1,6 @@
 const { google } = require("googleapis");
 const oAuth2Client = require("./googleClient");
 const _ = require("lodash");
-const { getConfigEnv } = require("../common");
-
-getConfigEnv();
 
 oAuth2Client.setCredentials({
   access_token: process.env.SHEETS_ACCESS_TOKEN,

--- a/src/lib/plaid/plaid.js
+++ b/src/lib/plaid/plaid.js
@@ -1,7 +1,5 @@
 const moment = require("moment");
-const { getConfigEnv, writeConfigProperty } = require("../common");
-
-getConfigEnv();
+const { writeConfigProperty } = require("../common");
 
 const plaidClient = require("./plaidClient");
 

--- a/src/lib/plaid/plaidClient.js
+++ b/src/lib/plaid/plaidClient.js
@@ -1,7 +1,3 @@
-const { getConfigEnv } = require('../common')
-
-getConfigEnv()
-
 const plaid = require('plaid')
 
 const environment = () => {

--- a/src/providers/plaid.js
+++ b/src/providers/plaid.js
@@ -1,9 +1,5 @@
 const moment = require('moment')
 const _ = require('lodash')
-const { getConfigEnv } = require('../lib/common')
-
-getConfigEnv()
-
 const { fetchTransactions, fetchBalances } = require('../lib/plaid/plaid')
 
 exports.getTransactions = async (transactionColumns, categoryOverrides, currentMonthSheetTitle) => {


### PR DESCRIPTION
Many files were unnecessarily importing config – during CI builds only the entry-point script gets access to the current set of environment variables. Safe to remove these and output is cleaner.