### PR TITLE
Fix for undefined Plaid account names

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "mintable.js",
   "author": "Kevin Schaich",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "circleci:dry-run": "circleci local execute -e MINTABLE_CONFIG=$MINTABLE_CONFIG",
     "export": "node ./src/scripts/export.js",

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -13,7 +13,7 @@ const DEFAULT_CONFIG = {
     'date',
     'amount',
     'name',
-    'account_details.official_name',
+    'account',
     'category.0',
     'category.1',
     'pending'

--- a/src/lib/plaid.js
+++ b/src/lib/plaid.js
@@ -147,7 +147,8 @@ const fetchAllCleanTransactions = async (startDate, endDate, pageSize = 250, off
         official_name: account.official_name,
         name: account.name,
         nickname: transaction.accountNickname
-      }
+      },
+      account: account.official_name || account.name || transaction.accountNickname
     }
   })
 


### PR DESCRIPTION
Sometimes `account_details.official_name` and `account_details.name` are undefined for Plaid. This will enable users to rather choose an `account` property, which preferences the most complete data available.

Closes #16 and #17 