### PR TITLE
Sanitize whitespace from config objects.

### DIFF
--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -101,10 +101,27 @@ const getConfigEnv = async options =>
     options
   )
 
+const sanitizeConfig = config => {
+  // recurse configuration objects and arrays to remove whitespace
+  const sanitize = (chunk) => {
+    return _.reduce(chunk, (result, v, k) => {
+      if (_.isObject(v) || _.isArray(v)) {
+        result[k] = sanitize(v);
+      } else {
+        result[k] = _.trim(v);
+      }
+
+      return result;
+    }, _.isArray(chunk) ? [] : {})
+  }
+
+  return sanitize(config);
+}
+
 const writeConfig = async newConfig =>
   wrapPromise(
     new Promise(async (resolve, reject) => {
-      fs.writeFileSync(CONFIG_FILE, JSON.stringify(newConfig, null, 2))
+      fs.writeFileSync(CONFIG_FILE, JSON.stringify(sanitizeConfig(newConfig), null, 2))
       resolve(getConfigEnv())
     }),
     'Writing config'

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -107,8 +107,10 @@ const sanitizeConfig = config => {
     return _.reduce(chunk, (result, v, k) => {
       if (_.isObject(v) || _.isArray(v)) {
         result[k] = sanitize(v);
-      } else {
+      } else if (_.isString()) {
         result[k] = _.trim(v);
+      } else {
+        result[k] = v;
       }
 
       return result;


### PR DESCRIPTION
This commit adds logic to recursively sanitize the configuration object before it's written out to disk. It trims leading and trailing whitespace from string values in arrays or objects.

Fixes #42