### PR TITLE
Exit with non-zero exit code from `yarn mintable`

### DIFF
--- a/src/scripts/mintable.js
+++ b/src/scripts/mintable.js
@@ -186,4 +186,7 @@
     default:
       break
   }
-})()
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+})


### PR DESCRIPTION
On failure, catch rejected promises and exit with a non-zero exit code to break the build.

Relates to the issue brought up on #43. Note that, because @kevinschaich 's secret configuration is not available on this fork, the build will fail. However, that's the expected behavior. See https://github.com/kevinschaich/mintable/pull/43#issuecomment-580530075 .