### PR TITLE
Added Discover Card CSV Import Template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,9 @@ You'll need to define a transformer to map properties in your source CSV spreads
 We have a number of templates available for popular financial institutions if you want to take this route:
 
 - [Apple Card](./templates/apple-card.json)
+- [Discover Card](./templates/discover-card.json)
+
+These templates can be added into the `accounts` section of your `mintable.jsonc` configuration file.
 
 ## Updating Transactions/Accounts
 

--- a/docs/templates/discover-card.json
+++ b/docs/templates/discover-card.json
@@ -1,0 +1,17 @@
+{
+    "accounts": {
+        "Discover Card": {
+            "paths": ["/path/to/my/discover/card/statements/*.csv"],
+            "transformer": {
+                "Description": "name",
+                "Trans. Date": "date",
+                "Amount": "amount",
+                "Category": "category"
+            },
+            "dateFormat": "MM/dd/yyyy",
+            "id": "Discover Card",
+            "integration": "csv-import",
+            "negateValues": true
+        }
+    }
+}


### PR DESCRIPTION
Discover Card's statements are available to download as a CSV at https://card.discover.com/cardmembersvcs/statements/app/activity#/current

-----------

I've verified the import works manually using my own CSV file.

When I originally made the template, using the App Card template as a guide, I wasn't sure where I needed to put the template so I added another sentence below the list of templates with a brief explanation on where a user should add them.