### PR TITLE
Add institution names on account set-up view

### DIFF
--- a/docs/css/account-setup.css
+++ b/docs/css/account-setup.css
@@ -45,11 +45,16 @@ h3 {
 
 th {
     font-weight: 700;
+    padding: 20px;
 }
 
 td {
     font-weight: 400;
     color: #333;
+    padding: 10px 30px;
+    border-top: 1px solid rgb(235, 235, 235);
+    background: #fff;
+    white-space: pre;
 }
 
 #accounts {
@@ -64,16 +69,6 @@ td {
 
 p {
     padding: 10px 40px;
-}
-
-th {
-    padding: 20px;
-}
-
-td {
-    padding: 10px 20px;
-    border-top: 1px solid rgb(235, 235, 235);
-    background: #fff;
 }
 
 button {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mintable",
     "author": "Kevin Schaich <schaich.kevin@gmail.com> (http://kevinschaich.io)",
     "license": "MIT",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "bin": "./lib/scripts/cli.js",
     "preferGlobal": true,
     "scripts": {

--- a/src/integrations/plaid/account-setup.html
+++ b/src/integrations/plaid/account-setup.html
@@ -48,13 +48,15 @@
                     } else {
                         const text = `<h3>Current Accounts</h3>`
                         $('#accounts').prepend(text)
-                        const table = `<table><tr><th>Token</th><th>Name</th><th>Update</th><th>Remove</th></tr></table>`
+                        const table = `<table><tr><th>Institution</th><th>Account(s)</th><th>Update</th><th>Remove</th></tr></table>`
                         $('#accounts-table').append(table)
 
                         accounts.forEach(account => {
                             const updateButton = `<button class="update" data-access-token="${account.token}">Update</button>`
                             const removeButton = `<button class="remove" data-access-token="${account.token}">Remove</button>`
-                            const row = `<tr><td>${account.token}</td><td>${account.name}</td><td>${updateButton}</td><td>${removeButton}</td></tr>`
+                            const row = `<tr><td>${account.institution}</td><td>${account.accountNames.join(
+                                '\n'
+                            )}</td><td>${updateButton}</td><td>${removeButton}</td></tr>`
                             $('#accounts table').append(row)
                         })
                     }


### PR DESCRIPTION
After fetching the accounts, we'll do a fetch for the institution that the accounts belong to.

Thoughts on this property living in the config file for the account? It's unlikely it could ever change, but if it does we could update the config on a fetch.