### PR TITLE
Allow transactions to be exported into a single sheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mintable",
     "author": "Kevin Schaich <schaich.kevin@gmail.com> (http://kevinschaich.io)",
     "license": "MIT",
-    "version": "2.0.1",
+    "version": "2.0.4",
     "bin": "./lib/scripts/cli.js",
     "preferGlobal": true,
     "scripts": {

--- a/src/integrations/google/googleIntegration.ts
+++ b/src/integrations/google/googleIntegration.ts
@@ -335,17 +335,26 @@ export class GoogleIntegration {
         // Sort transactions by date
         const transactions = sortBy(accounts.map(account => account.transactions).flat(10), 'date')
 
-        // Split transactions by month
-        const groupedTransactions = groupBy(transactions, transaction => formatISO(startOfMonth(transaction.date)))
-
-        // Write transactions by month, copying template sheet if necessary
-        for (const month in groupedTransactions) {
+        if (this.googleConfig.exportToSingleSheet) {
             await this.updateSheet(
-                format(parseISO(month), this.googleConfig.dateFormat || 'yyyy.MM'),
-                groupedTransactions[month],
+                this.googleConfig.singleSheetName ?? "Transactions",
+                transactions,
                 this.config.transactions.properties,
                 true
-            )
+                )
+        } else {
+            // Split transactions by month
+            const groupedTransactions = groupBy(transactions, transaction => formatISO(startOfMonth(transaction.date)))
+
+            // Write transactions by month, copying template sheet if necessary
+            for (const month in groupedTransactions) {
+                await this.updateSheet(
+                    format(parseISO(month), this.googleConfig.dateFormat || 'yyyy.MM'),
+                    groupedTransactions[month],
+                    this.config.transactions.properties,
+                    true
+                )
+            }
         }
 
         // Sort Sheets

--- a/src/types/integrations/google.ts
+++ b/src/types/integrations/google.ts
@@ -9,7 +9,7 @@ export interface GoogleCredentials {
   clientId: string
   clientSecret: string
   redirectUri: string
-  
+
   accessToken?: string
   refreshToken?: string
   scope?: string[]
@@ -23,8 +23,13 @@ export interface GoogleConfig extends BaseIntegrationConfig {
 
   credentials: GoogleCredentials
   documentId: string
-  
+
   dateFormat?: string
+
+  // Whether to export all transactions to a single sheet. Defaults to false (transactions are split by month)
+  exportToSingleSheet?: boolean
+  // If `exportToSingleSheet` is true, this controls the name of the exported sheet. Defaults to "Transactions"
+  singleSheetName?: string
 
   template?: GoogleTemplateSheetSettings
 }


### PR DESCRIPTION
Instead of being split by month. Config still defaults to the existing behaviour though.