### PR TITLE
Allow pending transaction ID to be a valid field

### DIFF
--- a/src/integrations/plaid/plaidIntegration.ts
+++ b/src/integrations/plaid/plaidIntegration.ts
@@ -231,6 +231,7 @@ export class PlaidIntegration {
                     type: transaction.transaction_type,
                     accountId: transaction.account_id,
                     transactionId: transaction.transaction_id,
+                    pendingtransactionId: transaction.pending_transaction_id,
                     category: transaction.category.join(' - '),
                     address: transaction.location.address,
                     city: transaction.location.city,


### PR DESCRIPTION
Pulls in associated pending transaction ID for a confirmed transaction, which makes it slightly easier to reconcile when you have a rolling log