### PR TITLE
🐞 Fix #155: Handle null category in transactions

### DIFF
--- a/src/integrations/plaid/plaidIntegration.ts
+++ b/src/integrations/plaid/plaidIntegration.ts
@@ -232,7 +232,7 @@ export class PlaidIntegration {
                     accountId: transaction.account_id,
                     transactionId: transaction.transaction_id,
                     pendingtransactionId: transaction.pending_transaction_id,
-                    category: transaction.category.join(' - '),
+                    category: (transaction.category || []).join(' - '),
                     address: transaction.location.address,
                     city: transaction.location.city,
                     state: transaction.location.region,


### PR DESCRIPTION
Fixes #155 caused due to Plaid starting to return null `category` in transactions. I can't find any announcement around this API change, except the vague mention of "Category accuracy boost" [here](https://plaid.com/blog/changelog-march-2023/#personal-finance-insights). Anyhoo, this patch fixed the crash for me.